### PR TITLE
Disable autoDiscover

### DIFF
--- a/DropZone.php
+++ b/DropZone.php
@@ -64,9 +64,8 @@ class DropZone extends \yii\base\Widget
     public function registerAssets()
     {
         $view = $this->getView();
-        DropZoneAsset::register($view);
 
-        $js = 'var ' . $this->id . ' = new Dropzone("div#' . $this->dropzoneContainer . '", ' . Json::encode($this->options) . ');';
+        $js = 'Dropzone.autoDiscover = false;var ' . $this->id . ' = new Dropzone("div#' . $this->dropzoneContainer . '", ' . Json::encode($this->options) . ');';
 
         if (!empty($this->clientEvents)) {
             foreach ($this->clientEvents as $event => $handler) {
@@ -75,5 +74,6 @@ class DropZone extends \yii\base\Widget
         }
 
         $view->registerJs($js);
+        DropZoneAsset::register($view);
     }
 }


### PR DESCRIPTION
When you don't have a form, the autoDiscover feature of DropZone creates a new instance of DropZone with option.url=null. This results in an Error thrown in dropzone.js on line 595, before the instantiation on line 68 of DropZone.php is executed. 
I have added Dropzone.autoDiscover = false; and moved the DropZoneAsset::register($view) down to make sure that disabling autoDiscover is being applied.
